### PR TITLE
fix: correct revert expectations in CLPool.testSwap

### DIFF
--- a/test/pool-cl/libraries/CLPool.t.sol
+++ b/test/pool-cl/libraries/CLPool.t.sol
@@ -144,39 +144,28 @@ contract PoolTest is Test {
             return;
         }
 
-        uint24 swapFee = swapParams.lpFeeOverride.isOverride()
+        uint24 lpSwapFee = swapParams.lpFeeOverride.isOverride()
             ? swapParams.lpFeeOverride.removeOverrideAndValidate(LPFeeLibrary.ONE_HUNDRED_PERCENT_FEE)
             : lpFee;
+        /// @dev the fee charged on the swap is the combination of the protocol fee and the lp fee
+        uint16 swapProtocolFee = swapParams.zeroForOne ? protocolFee.getZeroForOneFee() : protocolFee.getOneForZeroFee();
+        uint24 swapFee =
+            swapProtocolFee == 0 ? lpSwapFee : ProtocolFeeLibrary.calculateSwapFee(swapProtocolFee, lpSwapFee);
 
-        if (swapParams.zeroForOne) {
-            if (swapParams.sqrtPriceLimitX96 >= slot0.sqrtPriceX96()) {
-                vm.expectRevert(
-                    abi.encodeWithSelector(
-                        CLPool.InvalidSqrtPriceLimit.selector, slot0.sqrtPriceX96(), swapParams.sqrtPriceLimitX96
-                    )
-                );
-            } else if (swapParams.sqrtPriceLimitX96 <= TickMath.MIN_SQRT_RATIO) {
-                vm.expectRevert(
-                    abi.encodeWithSelector(
-                        CLPool.InvalidSqrtPriceLimit.selector, slot0.sqrtPriceX96(), swapParams.sqrtPriceLimitX96
-                    )
-                );
-            }
-        } else if (!swapParams.zeroForOne) {
-            if (swapParams.sqrtPriceLimitX96 <= slot0.sqrtPriceX96()) {
-                vm.expectRevert(
-                    abi.encodeWithSelector(
-                        CLPool.InvalidSqrtPriceLimit.selector, slot0.sqrtPriceX96(), swapParams.sqrtPriceLimitX96
-                    )
-                );
-            } else if (swapParams.sqrtPriceLimitX96 >= TickMath.MAX_SQRT_RATIO) {
-                vm.expectRevert(
-                    abi.encodeWithSelector(
-                        CLPool.InvalidSqrtPriceLimit.selector, slot0.sqrtPriceX96(), swapParams.sqrtPriceLimitX96
-                    )
-                );
-            }
-        } else if (swapParams.amountSpecified <= 0 && swapFee == LPFeeLibrary.ONE_HUNDRED_PERCENT_FEE) {
+        bool invalidSqrtPriceLimit = swapParams.zeroForOne
+            ? (swapParams.sqrtPriceLimitX96 >= slot0.sqrtPriceX96()
+                    || swapParams.sqrtPriceLimitX96 <= TickMath.MIN_SQRT_RATIO)
+            : (swapParams.sqrtPriceLimitX96 <= slot0.sqrtPriceX96()
+                    || swapParams.sqrtPriceLimitX96 >= TickMath.MAX_SQRT_RATIO);
+
+        if (invalidSqrtPriceLimit) {
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    CLPool.InvalidSqrtPriceLimit.selector, slot0.sqrtPriceX96(), swapParams.sqrtPriceLimitX96
+                )
+            );
+        } else if (swapFee >= LPFeeLibrary.ONE_HUNDRED_PERCENT_FEE && swapParams.amountSpecified >= 0) {
+            /// @dev a swap fee totaling 100% makes exact output swaps impossible
             vm.expectRevert(CLPool.InvalidFeeForExactOut.selector);
         }
 


### PR DESCRIPTION
## Problem

CI intermittently fails on `test/pool-cl/libraries/CLPool.t.sol:PoolTest::testSwap`:

```
[FAIL: InvalidFeeForExactOut(); counterexample: ...
  SwapParams({ zeroForOne: false, amountSpecified: 14857, lpFeeOverride: 1000001 }),
  lpFee: 1000000, protocolFee0: 20745, protocolFee1: 19416 ]
  (runs: 5743)
```

`CLPool.swap()` correctly reverts here — the test simply never registered the expectation. No contract change is needed.

## Root cause

The revert expectations in `testSwap` were structured as:

```solidity
if (swapParams.zeroForOne) { ... }
else if (!swapParams.zeroForOne) { ... }
else if (swapParams.amountSpecified <= 0 && swapFee == LPFeeLibrary.ONE_HUNDRED_PERCENT_FEE) {
    vm.expectRevert(CLPool.InvalidFeeForExactOut.selector);
}
```

Three separate defects:

1. **The `InvalidFeeForExactOut` branch is unreachable.** `zeroForOne` / `!zeroForOne` already exhaust the boolean, so that `vm.expectRevert` has never executed. `state.swap()` runs unconditionally on the next line, so when the pool legitimately reverts the test fails.
2. **The condition is inverted.** `CLPool.swap()` defines `exactInput = amountSpecified < 0`, so exact-output is `amountSpecified >= 0`. `amountSpecified` is bounded to `[0, int128.max]`, making `<= 0` almost always false.
3. **`swapFee` ignored the protocol fee.** The test compared `lpFee` alone, while the pool uses `ProtocolFeeLibrary.calculateSwapFee(protocolFee, lpFee)`. Because that helper rounds up, `lpFee = 999_999` combined with any `protocolFee >= 1` also reaches exactly 100%, which the old check would have missed even if the branch had been reachable.

In the failing counterexample `lpFeeOverride = 1000001` does **not** carry `OVERRIDE_FEE_FLAG` (`0x400000`), so the pool used `slot0.lpFee = 1_000_000`; combined with `protocolFee1 = 3412` for the one-for-zero direction the swap fee is exactly `1_000_000`, and `amountSpecified = 14857 > 0` makes it an exact-output swap.

The failure is rare because it requires `bound(lpFee, 0, ONE_HUNDRED_PERCENT_FEE)` to land on `999_999` or `1_000_000`. `ONE_HUNDRED_PERCENT_FEE` is a bytecode constant, so it is in the fuzzer dictionary, and `bound` returns in-range dictionary values unchanged — hence it surfaces at CI's 100k runs but not at the local default of 5.

## Fix

Test-only change to `testSwap`:

- Collapse the price-limit checks into a single `invalidSqrtPriceLimit` boolean so the `if / else if` chain is keyed on *which* revert is expected rather than on `zeroForOne`, making the `InvalidFeeForExactOut` branch reachable. The ordering mirrors the check order inside `CLPool.swap()`.
- Compute the expected swap fee the way the pool does: pick the directional protocol fee via `getZeroForOneFee()` / `getOneForZeroFee()`, then combine through `ProtocolFeeLibrary.calculateSwapFee()`.
- Use `amountSpecified >= 0` to match the pool's `exactInput` definition.

## Verification

- Replayed the CI counterexample as a deterministic test: fails on `main`, passes on this branch.
- `testSwap` across 40 fuzz seeds x 100,000 runs: all green.
- Full `CLPool.t.sol` suite at 20,000 runs and under `FOUNDRY_PROFILE=ci_main` (100,000 runs): all green.
- `forge fmt --check` clean.

---